### PR TITLE
fix: do not replace existing labels for renovate labels

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,23 +37,22 @@
   ],
   // https://docs.renovatebot.com/configuration-options/#prbodynotes
   "prBodyNotes": [
-    "Reviewer is responsible for dependency update. Ensure adequate automated",
-    "or manual testing is performed before merge.",
+    "Reviewer is responsible for dependency update. Ensure adequate automated or manual testing is performed before merge.",
   ],
 
   "packageRules": [
     // Report impact of a dependency update via PR label.
     {
       "matchUpdateTypes": ["patch"],
-       "labels": ["semver: patch"],
+       "addLabels": ["semver: patch"],
     },
     {
       "matchUpdateTypes": ["minor"],
-       "labels": ["semver: minor"],
+       "addLabels": ["semver: minor"],
     },
     {
       "matchUpdateTypes": ["major"],
-       "labels": ["semver: major"],
+       "addLabels": ["semver: major"],
     },
 
     // Language-specific behaviors.


### PR DESCRIPTION
Renovate `labels` removes all existing labels. Instead, use `addLabels` so renovate can complement existing labels.